### PR TITLE
Add Suede Creator Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
-| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 166 ⭐ | 67 MIT-licensed skills for Claude Code and Codex covering code quality, design, marketing, agent workflows, and mobile shipping. |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 153 ⭐ | MIT-licensed skills pack for Claude Code and Codex covering code quality, design, marketing, agent workflows, and mobile shipping. |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
-| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 153 ⭐ | MIT-licensed skills pack for Claude Code and Codex covering code quality, design, marketing, agent workflows, and mobile shipping. |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 129 ⭐ | MIT-licensed skills pack for Claude Code and Codex covering code quality, design, marketing, agent workflows, and mobile shipping. |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 166 ⭐ | 67 MIT-licensed skills for Claude Code and Codex covering code quality, design, marketing, agent workflows, and mobile shipping. |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |

--- a/README_CN.md
+++ b/README_CN.md
@@ -333,7 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
-| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 153 ⭐ | MIT 许可的 Claude Code 与 Codex Skills 合集，覆盖代码质量、设计、营销、Agent 工作流和移动应用发布。 |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 129 ⭐ | MIT 许可的 Claude Code 与 Codex Skills 合集，覆盖代码质量、设计、营销、Agent 工作流和移动应用发布。 |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |

--- a/README_CN.md
+++ b/README_CN.md
@@ -333,6 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 166 ⭐ | 67 个 MIT 许可的 Claude Code 与 Codex Skills，覆盖代码质量、设计、营销、Agent 工作流和移动应用发布。 |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |

--- a/README_CN.md
+++ b/README_CN.md
@@ -333,7 +333,7 @@
 | [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts) | 5k ⭐ | This repo includes Claude prompt curation to use Claude better. |
 | [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) | 4.4k ⭐ | Tutorials, Guides and Agent Skills Directories |
 | [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) | 4.2k ⭐ | Agent Skills 终极指南：快速入门、资源推荐、精选技能与实用工具 ｜The Ultimate Guide to Agent Skills: QuickStart, Resources, Features&Toolkit |
-| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 166 ⭐ | 67 个 MIT 许可的 Claude Code 与 Codex Skills，覆盖代码质量、设计、营销、Agent 工作流和移动应用发布。 |
+| [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) | 153 ⭐ | MIT 许可的 Claude Code 与 Codex Skills 合集，覆盖代码质量、设计、营销、Agent 工作流和移动应用发布。 |
 | [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) | 3.5k ⭐ | Curated list of awesome Cursor Rules .mdc files |
 | [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) | 1.5k ⭐ | The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via SkillKit), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more. |
 | [Prat011/awesome-llm-skills](https://github.com/Prat011/awesome-llm-skills) | 1.2k ⭐ | A curated list of awesome LLM and AI Agent Skills, resources and tools for customising AI Agent workflows - that works with Claude Code, Codex, Gemini CLI and your custom AI Agents |


### PR DESCRIPTION
## Summary

Adds Suede Creator Skills to the English and Chinese Awesome Lists and Collections tables.

## Verification

- Confirmed 67 public skill folders and 166 current GitHub stars.
- Confirmed Claude Code and Codex support.
- Updated both language variants with matching facts.
- Ran git diff --check.